### PR TITLE
Moonstrike Detection

### DIFF
--- a/src-tauri/src/live/opcodes_models.rs
+++ b/src-tauri/src/live/opcodes_models.rs
@@ -664,7 +664,7 @@ pub mod class {
     pub fn get_class_spec_from_skill_id(skill_id: i32) -> ClassSpec {
         match skill_id {
             1714 | 1734 => ClassSpec::Iaido,
-            44701 | 179906 => ClassSpec::Moonstrike,
+            1715 | 1733 | 1742 => ClassSpec::Moonstrike,
 
             120901 | 120902 => ClassSpec::Icicle,
             1241 => ClassSpec::Frostbeam,


### PR DESCRIPTION
Removed Scythe Wheel (IDs 44701 and 179906) from detection, as this skill is also commonly used by Iaido builds.

Replaced it with Moonstrike, Storm Scythe, and Thundercleave (IDs 1715, 1733, and 1742).